### PR TITLE
fix: public ingress URLs for NEXT_PUBLIC_* vars & Neo4j hostname

### DIFF
--- a/charts/prowler/Chart.yaml
+++ b/charts/prowler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prowler
 description: Prowler is an Open Cloud Security tool for AWS, Azure, GCP and Kubernetes. It helps for continuous monitoring, security assessments and audits, incident response, compliance, hardening and forensics readiness. 
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: "5.20.0"
 home: https://prowler.com/
 icon: https://promptlylabs.github.io/prowler-helm-chart/docs/images/prowler-icon.jpeg
@@ -42,10 +42,16 @@ annotations:
     - name: support
       url: https://github.com/promptlylabs/prowler-helm-chart/issues
   artifacthub.io/changes: |
-    - kind: changed
-      description: Updated appVersion to 5.20.0
-    - kind: added
-      description: Note about official Prowler Helm Chart availability in READMEs
+    - kind: fixed
+      description: "NEXT_PUBLIC_API_BASE_URL and NEXT_PUBLIC_API_DOCS_URL now use the API ingress host when ingress is enabled, so the browser can reach the API"
+      links:
+        - name: Github PR
+          url: https://github.com/promptlylabs/prowler-helm-chart/pull/6
+    - kind: fixed
+      description: "NEO4J_HOST now uses the Neo4j subchart's fullname helper, fixing hostname mismatch when release name differs from 'prowler'"
+      links:
+        - name: Github PR
+          url: https://github.com/promptlylabs/prowler-helm-chart/pull/6
 #   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/screenshots: |
     - title: Login

--- a/charts/prowler/templates/api/secret-neo4j.yaml
+++ b/charts/prowler/templates/api/secret-neo4j.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "prowler.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  NEO4J_HOST: "{{ include "prowler.fullname" . }}-neo4j"
+  NEO4J_HOST: "{{ include "neo4j.fullname" .Subcharts.neo4j }}"
   NEO4J_PORT: "7687"
   NEO4J_USER: "neo4j"
   NEO4J_PASSWORD: {{ .Values.neo4j.neo4j.password | quote }}

--- a/charts/prowler/templates/ui/configmap.yaml
+++ b/charts/prowler/templates/ui/configmap.yaml
@@ -12,8 +12,15 @@ data:
   AUTH_URL: "http://localhost:{{ .Values.ui.service.port }}"
   {{- end }}
   API_BASE_URL: "http://{{ include "prowler.fullname" . }}-api:{{ .Values.api.service.port }}/api/v1"
+  {{- if .Values.api.ingress.enabled }}
+  {{- with (first .Values.api.ingress.hosts) }}
+  NEXT_PUBLIC_API_BASE_URL: "https://{{ .host }}/api/v1"
+  NEXT_PUBLIC_API_DOCS_URL: "https://{{ .host }}/api/v1/docs"
+  {{- end }}
+  {{- else }}
   NEXT_PUBLIC_API_BASE_URL: "http://{{ include "prowler.fullname" . }}-api:{{ .Values.api.service.port }}/api/v1"
   NEXT_PUBLIC_API_DOCS_URL: "http://{{ include "prowler.fullname" . }}-api:{{ .Values.api.service.port }}/api/v1/docs"
+  {{- end }}
   AUTH_TRUST_HOST: "true"
   UI_PORT: {{ .Values.ui.service.port | quote }}
   # openssl rand -base64 32


### PR DESCRIPTION
## Summary
- **NEXT_PUBLIC_API_BASE_URL / NEXT_PUBLIC_API_DOCS_URL**: These client-side env vars were hardcoded to the internal cluster service URL. Since `NEXT_PUBLIC_*` variables are embedded in the browser JS bundle, the browser couldn't reach the API, causing "Network error or server is unreachable" on sign-up and other actions. Now mirrors the `AUTH_URL` pattern — uses the API ingress host when `api.ingress.enabled`, falls back to internal URL otherwise.
- **NEO4J_HOST**: Was constructed as `{{ prowler.fullname }}-neo4j`, but the Neo4j subchart uses `fullnameOverride: "prowler-neo4j"`. When the release name wasn't "prowler", the API couldn't connect to Neo4j. Now uses `{{ include "neo4j.fullname" .Subcharts.neo4j }}` to always match the subchart's actual service name.
- Bumps chart version to **0.0.5**.

## Test plan
- [x] `helm template` with `api.ingress.enabled=true` — verify `NEXT_PUBLIC_*` use the ingress host with HTTPS
- [x] `helm template` with ingress disabled — verify `NEXT_PUBLIC_*` fall back to internal service URL
- [x] `helm template` with a non-"prowler" release name — verify `NEO4J_HOST` is still `prowler-neo4j`
- [ ] Deploy to a cluster with ingress and confirm UI sign-up works