### PR TITLE
fix: use subchart fullname helpers for PostgreSQL & Valkey hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Images should use relative URLs.
 
 # Prowler Helm Chart
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square)
 ![AppVersion: 5.20.0](https://img.shields.io/badge/AppVersion-5.20.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/prowler-app)](https://artifacthub.io/packages/helm/prowler-app/prowler)
 

--- a/charts/prowler/Chart.yaml
+++ b/charts/prowler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prowler
 description: Prowler is an Open Cloud Security tool for AWS, Azure, GCP and Kubernetes. It helps for continuous monitoring, security assessments and audits, incident response, compliance, hardening and forensics readiness. 
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: "5.20.0"
 home: https://prowler.com/
 icon: https://promptlylabs.github.io/prowler-helm-chart/docs/images/prowler-icon.jpeg
@@ -18,7 +18,7 @@ maintainers:
 dependencies:
   # https://artifacthub.io/packages/helm/bitnami/postgresql
   - name: postgresql
-    version: 18.5.2
+    version: 18.5.6
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   # https://artifacthub.io/packages/helm/bitnami/valkey
@@ -28,7 +28,7 @@ dependencies:
     condition: valkey.enabled
   # https://artifacthub.io/packages/helm/neo4j-helm-charts/neo4j
   - name: neo4j
-    version: 2026.1.4
+    version: 2026.2.2
     repository: https://neo4j.github.io/helm-charts/
     condition: neo4j.enabled
 annotations: 
@@ -43,15 +43,19 @@ annotations:
       url: https://github.com/promptlylabs/prowler-helm-chart/issues
   artifacthub.io/changes: |
     - kind: fixed
-      description: "NEXT_PUBLIC_API_BASE_URL and NEXT_PUBLIC_API_DOCS_URL now use the API ingress host when ingress is enabled, so the browser can reach the API"
+      description: "POSTGRES_HOST now uses the PostgreSQL subchart's fullname helper, fixing hostname mismatch when fullnameOverride is set or release name differs"
       links:
         - name: Github PR
-          url: https://github.com/promptlylabs/prowler-helm-chart/pull/6
+          url: https://github.com/promptlylabs/prowler-helm-chart/pull/7
     - kind: fixed
-      description: "NEO4J_HOST now uses the Neo4j subchart's fullname helper, fixing hostname mismatch when release name differs from 'prowler'"
+      description: "VALKEY_HOST now uses the Valkey subchart's fullname helper, fixing hostname mismatch when fullnameOverride is set or release name differs"
       links:
         - name: Github PR
-          url: https://github.com/promptlylabs/prowler-helm-chart/pull/6
+          url: https://github.com/promptlylabs/prowler-helm-chart/pull/7
+    - kind: changed
+      description: "Updated PostgreSQL subchart from 18.5.2 to 18.5.6"
+    - kind: changed
+      description: "Updated Neo4j subchart from 2026.1.4 to 2026.2.2"
 #   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/screenshots: |
     - title: Login

--- a/charts/prowler/README.md
+++ b/charts/prowler/README.md
@@ -5,7 +5,7 @@ Images should use absolute URLs.
 
 # Prowler Helm Chart
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square)
 ![AppVersion: 5.20.0](https://img.shields.io/badge/AppVersion-5.20.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/prowler-app)](https://artifacthub.io/packages/helm/prowler-app/prowler)
 

--- a/charts/prowler/templates/api/secret-postgres.yaml
+++ b/charts/prowler/templates/api/secret-postgres.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "prowler.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  POSTGRES_HOST: "{{ include "prowler.fullname" . }}-postgresql"
+  POSTGRES_HOST: "{{ include "postgresql.v1.primary.fullname" .Subcharts.postgresql }}"
   POSTGRES_PORT: "5432"
   # Existing user
   POSTGRES_ADMIN_USER: postgres

--- a/charts/prowler/templates/api/secret-valkey.yaml
+++ b/charts/prowler/templates/api/secret-valkey.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "prowler.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  VALKEY_HOST: "{{ include "prowler.fullname" . }}-valkey-headless"
+  VALKEY_HOST: "{{ printf "%s-headless" (include "common.names.fullname" .Subcharts.valkey) }}"
   # VALKEY_PASSWORD: "valkey_password"
   VALKEY_PORT: "6379"
   VALKEY_DB: "0"


### PR DESCRIPTION
## Summary
- **POSTGRES_HOST** and **VALKEY_HOST** were constructed using the parent chart's `prowler.fullname` helper, but the actual subchart services use their own naming logic. This caused hostname mismatches when `fullnameOverride` was set or the release name differed from the chart name.
- Now uses `postgresql.v1.primary.fullname` and `common.names.fullname` with `.Subcharts` context — same pattern already used for Neo4j since v0.0.5.
- Updated PostgreSQL subchart 18.5.2 → 18.5.6 and Neo4j subchart 2026.1.4 → 2026.2.2.
- Updated README version badges to 0.0.6.
- Bumps chart version to **0.0.6**.

## Test plan
- [x] `helm template test-release` — hostnames match actual service names (`test-release-postgresql`, `test-release-valkey-headless`, `prowler-neo4j`)
- [x] `helm template test-release --set fullnameOverride=prowler` — hostnames still match when fullnameOverride is set
- [ ] Deploy to a cluster and confirm API connects to PostgreSQL and Valkey