### PR TITLE
feat: external secret support, security contexts, checksums & UI fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Images should use relative URLs.
 
 # Prowler Helm Chart
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square)
 ![AppVersion: 5.20.0](https://img.shields.io/badge/AppVersion-5.20.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/prowler-app)](https://artifacthub.io/packages/helm/prowler-app/prowler)
 

--- a/charts/prowler/Chart.yaml
+++ b/charts/prowler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prowler
 description: Prowler is an Open Cloud Security tool for AWS, Azure, GCP and Kubernetes. It helps for continuous monitoring, security assessments and audits, incident response, compliance, hardening and forensics readiness. 
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "5.20.0"
 home: https://prowler.com/
 icon: https://promptlylabs.github.io/prowler-helm-chart/docs/images/prowler-icon.jpeg
@@ -42,20 +42,28 @@ annotations:
     - name: support
       url: https://github.com/promptlylabs/prowler-helm-chart/issues
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "POSTGRES_HOST now uses the PostgreSQL subchart's fullname helper, fixing hostname mismatch when fullnameOverride is set or release name differs"
+    - kind: security
+      description: "Moved AUTH_SECRET from ConfigMap to a dedicated Secret resource with existingSecret support"
       links:
         - name: Github PR
-          url: https://github.com/promptlylabs/prowler-helm-chart/pull/7
-    - kind: fixed
-      description: "VALKEY_HOST now uses the Valkey subchart's fullname helper, fixing hostname mismatch when fullnameOverride is set or release name differs"
+          url: https://github.com/promptlylabs/prowler-helm-chart/pull/8
+    - kind: added
+      description: "External secret support via existingSecret for PostgreSQL, Valkey, Neo4j, and UI auth"
       links:
         - name: Github PR
-          url: https://github.com/promptlylabs/prowler-helm-chart/pull/7
+          url: https://github.com/promptlylabs/prowler-helm-chart/pull/8
+    - kind: added
+      description: "Checksum annotations on all deployments for automatic pod restarts on config/secret changes"
+    - kind: added
+      description: "Security context defaults for all components (runAsNonRoot, drop ALL capabilities)"
+    - kind: fixed
+      description: "UI probes now target /sign-in instead of / which caused redirect failures"
     - kind: changed
-      description: "Updated PostgreSQL subchart from 18.5.2 to 18.5.6"
-    - kind: changed
-      description: "Updated Neo4j subchart from 2026.1.4 to 2026.2.2"
+      description: "Worker-beat entrypoint changed to absolute path for consistency"
+    - kind: fixed
+      description: "Set fullnameOverride to 'prowler' so the API service matches the baked-in NEXT_PUBLIC_API_BASE_URL in the UI image"
+    - kind: added
+      description: "API startupProbe to allow time for DB migrations before liveness checks begin"
 #   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/screenshots: |
     - title: Login

--- a/charts/prowler/README.md
+++ b/charts/prowler/README.md
@@ -5,7 +5,7 @@ Images should use absolute URLs.
 
 # Prowler Helm Chart
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square)
 ![AppVersion: 5.20.0](https://img.shields.io/badge/AppVersion-5.20.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/prowler-app)](https://artifacthub.io/packages/helm/prowler-app/prowler)
 

--- a/charts/prowler/templates/api/deployment.yaml
+++ b/charts/prowler/templates/api/deployment.yaml
@@ -13,10 +13,23 @@ spec:
       app.kubernetes.io/name: {{ include "prowler.fullname" . }}-api
   template:
     metadata:
-      {{- with .Values.api.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/api/configmap.yaml") . | sha256sum }}
+        {{- if .Values.api.djangoConfigKeys.create }}
+        checksum/secret-django: {{ include (print $.Template.BasePath "/api/secret-django.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.postgresql.enabled (not .Values.postgresql.existingSecret) }}
+        checksum/secret-postgres: {{ include (print $.Template.BasePath "/api/secret-postgres.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.valkey.enabled (not .Values.valkey.existingSecret) }}
+        checksum/secret-valkey: {{ include (print $.Template.BasePath "/api/secret-valkey.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.neo4j.enabled (not .Values.neo4j.existingSecret) }}
+        checksum/secret-neo4j: {{ include (print $.Template.BasePath "/api/secret-neo4j.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.api.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "prowler.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ include "prowler.fullname" . }}-api
@@ -60,15 +73,24 @@ spec:
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-django-config-keys
             {{- end }}
-            {{- if .Values.postgresql.enabled }}
+            {{- if .Values.postgresql.existingSecret }}
+            - secretRef:
+                name: {{ .Values.postgresql.existingSecret }}
+            {{- else if .Values.postgresql.enabled }}
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-postgres
             {{- end }}
-            {{- if .Values.valkey.enabled }}
+            {{- if .Values.valkey.existingSecret }}
+            - secretRef:
+                name: {{ .Values.valkey.existingSecret }}
+            {{- else if .Values.valkey.enabled }}
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-valkey
             {{- end }}
-            {{- if .Values.neo4j.enabled }}
+            {{- if .Values.neo4j.existingSecret }}
+            - secretRef:
+                name: {{ .Values.neo4j.existingSecret }}
+            {{- else if .Values.neo4j.enabled }}
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-neo4j
             {{- end }}
@@ -78,6 +100,10 @@ spec:
                 name: {{ $secret }}
             {{- end }}
             {{- end }}
+          {{- with .Values.api.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.api.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/prowler/templates/api/secret-neo4j.yaml
+++ b/charts/prowler/templates/api/secret-neo4j.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.neo4j.enabled -}}
+{{- if and .Values.neo4j.enabled (not .Values.neo4j.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prowler/templates/api/secret-postgres.yaml
+++ b/charts/prowler/templates/api/secret-postgres.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgresql.enabled -}}
+{{- if and .Values.postgresql.enabled (not .Values.postgresql.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prowler/templates/api/secret-valkey.yaml
+++ b/charts/prowler/templates/api/secret-valkey.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.valkey.enabled -}}
+{{- if and .Values.valkey.enabled (not .Values.valkey.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/prowler/templates/ui/configmap.yaml
+++ b/charts/prowler/templates/ui/configmap.yaml
@@ -23,5 +23,3 @@ data:
   {{- end }}
   AUTH_TRUST_HOST: "true"
   UI_PORT: {{ .Values.ui.service.port | quote }}
-  # openssl rand -base64 32
-  AUTH_SECRET: "N/c6mnaS5+SWq81+819OrzQZlmx1Vxtp/orjttJSmw8:"

--- a/charts/prowler/templates/ui/deployment.yaml
+++ b/charts/prowler/templates/ui/deployment.yaml
@@ -13,10 +13,14 @@ spec:
       app.kubernetes.io/name: {{ include "prowler.fullname" . }}-ui
   template:
     metadata:
-      {{- with .Values.ui.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/ui/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.ui.authSecret.existingSecret }}
+        checksum/secret-auth: {{ include (print $.Template.BasePath "/ui/secret-auth.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.ui.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "prowler.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ include "prowler.fullname" . }}-ui
@@ -48,6 +52,13 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "prowler.fullname" . }}-ui
+            {{- if .Values.ui.authSecret.existingSecret }}
+            - secretRef:
+                name: {{ .Values.ui.authSecret.existingSecret }}
+            {{- else }}
+            - secretRef:
+                name: {{ include "prowler.fullname" . }}-ui-auth
+            {{- end }}
           {{- with .Values.ui.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/prowler/templates/ui/secret-auth.yaml
+++ b/charts/prowler/templates/ui/secret-auth.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.ui.authSecret.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "prowler.fullname" . }}-ui-auth
+  labels:
+    {{- include "prowler.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # openssl rand -base64 32
+  AUTH_SECRET: "N/c6mnaS5+SWq81+819OrzQZlmx1Vxtp/orjttJSmw8="
+{{- end -}}

--- a/charts/prowler/templates/worker/deployment.yaml
+++ b/charts/prowler/templates/worker/deployment.yaml
@@ -13,10 +13,23 @@ spec:
       app.kubernetes.io/name: {{ include "prowler.fullname" . }}-worker
   template:
     metadata:
-      {{- with .Values.worker.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/api/configmap.yaml") . | sha256sum }}
+        {{- if .Values.api.djangoConfigKeys.create }}
+        checksum/secret-django: {{ include (print $.Template.BasePath "/api/secret-django.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.postgresql.enabled (not .Values.postgresql.existingSecret) }}
+        checksum/secret-postgres: {{ include (print $.Template.BasePath "/api/secret-postgres.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.valkey.enabled (not .Values.valkey.existingSecret) }}
+        checksum/secret-valkey: {{ include (print $.Template.BasePath "/api/secret-valkey.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.neo4j.enabled (not .Values.neo4j.existingSecret) }}
+        checksum/secret-neo4j: {{ include (print $.Template.BasePath "/api/secret-neo4j.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.worker.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "prowler.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ include "prowler.fullname" . }}-worker
@@ -56,15 +69,24 @@ spec:
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-django-config-keys
             {{- end }}
-            {{- if .Values.postgresql.enabled }}
+            {{- if .Values.postgresql.existingSecret }}
+            - secretRef:
+                name: {{ .Values.postgresql.existingSecret }}
+            {{- else if .Values.postgresql.enabled }}
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-postgres
             {{- end }}
-            {{- if .Values.valkey.enabled }}
+            {{- if .Values.valkey.existingSecret }}
+            - secretRef:
+                name: {{ .Values.valkey.existingSecret }}
+            {{- else if .Values.valkey.enabled }}
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-valkey
             {{- end }}
-            {{- if .Values.neo4j.enabled }}
+            {{- if .Values.neo4j.existingSecret }}
+            - secretRef:
+                name: {{ .Values.neo4j.existingSecret }}
+            {{- else if .Values.neo4j.enabled }}
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-neo4j
             {{- end }}

--- a/charts/prowler/templates/worker_beat/deployment.yaml
+++ b/charts/prowler/templates/worker_beat/deployment.yaml
@@ -13,10 +13,23 @@ spec:
       app.kubernetes.io/name: {{ include "prowler.fullname" . }}-worker-beat
   template:
     metadata:
-      {{- with .Values.worker_beat.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/api/configmap.yaml") . | sha256sum }}
+        {{- if .Values.api.djangoConfigKeys.create }}
+        checksum/secret-django: {{ include (print $.Template.BasePath "/api/secret-django.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.postgresql.enabled (not .Values.postgresql.existingSecret) }}
+        checksum/secret-postgres: {{ include (print $.Template.BasePath "/api/secret-postgres.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.valkey.enabled (not .Values.valkey.existingSecret) }}
+        checksum/secret-valkey: {{ include (print $.Template.BasePath "/api/secret-valkey.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if and .Values.neo4j.enabled (not .Values.neo4j.existingSecret) }}
+        checksum/secret-neo4j: {{ include (print $.Template.BasePath "/api/secret-neo4j.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.worker_beat.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "prowler.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ include "prowler.fullname" . }}-worker-beat
@@ -56,15 +69,24 @@ spec:
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-django-config-keys
             {{- end }}
-            {{- if .Values.postgresql.enabled }}
+            {{- if .Values.postgresql.existingSecret }}
+            - secretRef:
+                name: {{ .Values.postgresql.existingSecret }}
+            {{- else if .Values.postgresql.enabled }}
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-postgres
             {{- end }}
-            {{- if .Values.valkey.enabled }}
+            {{- if .Values.valkey.existingSecret }}
+            - secretRef:
+                name: {{ .Values.valkey.existingSecret }}
+            {{- else if .Values.valkey.enabled }}
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-valkey
             {{- end }}
-            {{- if .Values.neo4j.enabled }}
+            {{- if .Values.neo4j.existingSecret }}
+            - secretRef:
+                name: {{ .Values.neo4j.existingSecret }}
+            {{- else if .Values.neo4j.enabled }}
             - secretRef:
                 name: {{ include "prowler.fullname" . }}-api-neo4j
             {{- end }}

--- a/charts/prowler/values.yaml
+++ b/charts/prowler/values.yaml
@@ -1,6 +1,9 @@
 # This is to override the chart name.
 nameOverride: ""
-fullnameOverride: ""
+# The prowler-ui Docker image has NEXT_PUBLIC_API_BASE_URL=http://prowler-api:8080/api/v1
+# baked into the JS bundle at build time (NEXT_PUBLIC_* vars cannot be overridden at runtime).
+# This means the API service MUST be named "prowler-api", which requires fullnameOverride: "prowler".
+fullnameOverride: "prowler"
 
 postgresql:
   # If enabled, it will create a Secret with the credentials.
@@ -13,6 +16,11 @@ postgresql:
   # - POSTGRES_PASSWORD
   # - POSTGRES_DB             - Existing DB
   enabled: true
+  # If set, the chart will NOT auto-create the PostgreSQL connection secret
+  # and will reference this existing secret instead (e.g. from External Secrets Operator).
+  # Required keys: POSTGRES_HOST, POSTGRES_PORT, POSTGRES_ADMIN_USER,
+  #   POSTGRES_ADMIN_PASSWORD, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB
+  existingSecret: ""
   global:
     postgresql:
       auth:
@@ -27,6 +35,10 @@ valkey:
   # - VALKEY_PASSWORD
   # - VALKEY_DB
   enabled: true
+  # If set, the chart will NOT auto-create the Valkey connection secret
+  # and will reference this existing secret instead (e.g. from External Secrets Operator).
+  # Required keys: VALKEY_HOST, VALKEY_PORT, VALKEY_PASSWORD, VALKEY_DB
+  existingSecret: ""
   architecture: "standalone"
   auth:
     enabled: false
@@ -40,6 +52,10 @@ neo4j:
   # - NEO4J_USER
   # - NEO4J_PASSWORD
   enabled: true
+  # If set, the chart will NOT auto-create the Neo4j connection secret
+  # and will reference this existing secret instead (e.g. from External Secrets Operator).
+  # Required keys: NEO4J_HOST, NEO4J_PORT, NEO4J_USER, NEO4J_PASSWORD
+  existingSecret: ""
   fullnameOverride: "prowler-neo4j"
   neo4j:
     name: "prowler-neo4j"
@@ -90,16 +106,21 @@ ui:
   # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
 
-  podSecurityContext: {}
-    # fsGroup: 2000
+  # If set, the chart won't create the auth secret and will reference this existing secret instead.
+  # Required key: AUTH_SECRET (obtain from `openssl rand -base64 32`)
+  authSecret:
+    existingSecret: ""
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  podSecurityContext:
+    fsGroup: 1001
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
   service:
@@ -139,11 +160,11 @@ ui:
   # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   livenessProbe:
     httpGet:
-      path: /
+      path: /sign-in
       port: http
   readinessProbe:
     httpGet:
-      path: /
+      path: /sign-in
       port: http
 
   # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
@@ -231,10 +252,12 @@ api:
     # Sentry (optional)
     # DJANGO_SENTRY_DSN: ""
     #
-    # Social login (optional) - add these via api.secrets
+    # SAML SSO (optional) - see https://docs.prowler.com/user-guide/tutorials/prowler-app-sso
+    # SAML_SSO_CALLBACK_URL: "https://api.example.com/api/v1/saml/acs"
+    #
+    # Social login (optional) - add OAuth credentials via api.secrets
     # SOCIAL_GOOGLE_OAUTH_CLIENT_ID, SOCIAL_GOOGLE_OAUTH_CLIENT_SECRET
     # SOCIAL_GITHUB_OAUTH_CLIENT_ID, SOCIAL_GITHUB_OAUTH_CLIENT_SECRET
-    # SAML_SSO_CALLBACK_URL
   djangoConfigKeys:
     # Create secret with Django Keys
     # If false, a secret needs to be created with the following:
@@ -274,16 +297,16 @@ api:
   # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
 
-  podSecurityContext: {}
-    # fsGroup: 2000
+  podSecurityContext:
+    fsGroup: 1000
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
   service:
@@ -320,11 +343,12 @@ api:
     #   cpu: 100m
     #   memory: 128Mi
 
-  # 3m30s to setup DB
-  # startupProbe:
-  #   httpGet:
-  #     path: /api/v1/docs
-  #     port: http
+  startupProbe:
+    httpGet:
+      path: /api/v1/docs
+      port: http
+    failureThreshold: 30
+    periodSeconds: 10
 
   # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   livenessProbe:
@@ -406,16 +430,16 @@ worker:
   # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
 
-  podSecurityContext: {}
-    # fsGroup: 2000
+  podSecurityContext:
+    fsGroup: 1000
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -428,7 +452,9 @@ worker:
     #   cpu: 100m
     #   memory: 128Mi
 
-  # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  # Celery workers don't expose HTTP endpoints, so httpGet probes are not applicable.
+  # Alternatives (exec probes with `celery inspect ping`) are unreliable when workers are busy processing tasks.
+  # See: https://medium.com/ambient-innovation/health-checks-for-celery-in-kubernetes-cf3274a3e106
   livenessProbe: {}
   readinessProbe: {}
 
@@ -473,7 +499,7 @@ worker_beat:
     tag: ""
   
   command:
-    - ../docker-entrypoint.sh
+    - /home/prowler/docker-entrypoint.sh
   args:
     - beat
 
@@ -499,16 +525,16 @@ worker_beat:
   # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
 
-  podSecurityContext: {}
-    # fsGroup: 2000
+  podSecurityContext:
+    fsGroup: 1000
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -521,7 +547,9 @@ worker_beat:
     #   cpu: 100m
     #   memory: 128Mi
 
-  # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  # Celery workers don't expose HTTP endpoints, so httpGet probes are not applicable.
+  # Alternatives (exec probes with `celery inspect ping`) are unreliable when workers are busy processing tasks.
+  # See: https://medium.com/ambient-innovation/health-checks-for-celery-in-kubernetes-cf3274a3e106
   livenessProbe: {}
   readinessProbe: {}
 


### PR DESCRIPTION
## Summary
- **fullnameOverride**: Set default to `prowler` so the API service is named `prowler-api`, matching the `NEXT_PUBLIC_API_BASE_URL` baked into the UI Docker image at build time
- **API startupProbe**: Added to allow time for DB migrations before liveness checks begin (up to 5 minutes)
- **External secret support**: Added `existingSecret` option for PostgreSQL, Valkey, Neo4j, and UI auth — enables production deployments with External Secrets Operator instead of chart-managed secrets with hardcoded dev defaults
- **AUTH_SECRET**: Moved from ConfigMap to a dedicated Secret resource with `ui.authSecret.existingSecret` support
- **Checksum annotations**: All deployments now have `sha256sum` annotations on pod templates, so pods automatically restart when config/secrets change during `helm upgrade`
- **Security contexts**: Set defaults for all components matching upstream Dockerfiles — `runAsNonRoot`, `allowPrivilegeEscalation: false`, `drop ALL` capabilities (UID 1000 for API/workers, UID 1001 for UI)
- **UI probes**: Changed from `/` (returns redirect) to `/sign-in`
- **Worker-beat**: Changed entrypoint to absolute path `/home/prowler/docker-entrypoint.sh` for consistency
- **Docs**: Added explanatory comments for empty Celery worker probes; improved SAML SSO documentation in values.yaml
- Bumps chart version to **0.0.7**

## Test plan
- [x] `helm template` default dev mode — all secrets auto-created, checksums present, security contexts applied
- [x] `helm template` with `existingSecret` set — external secrets referenced, auto-created secrets absent
- [x] AUTH_SECRET no longer in ConfigMap
- [x] UI probes target `/sign-in`
- [x] Worker-beat uses absolute entrypoint path
- [x] Deployed to kind cluster — all pods running, API service named `prowler-api`, no restarts thanks to startupProbe
- [x] UI accessible via port-forward, able to reach API