### PR TITLE
feat: Support HTTPRoute for UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Images should use relative URLs.
 
 # Prowler Helm Chart
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square)
 ![AppVersion: 5.20.0](https://img.shields.io/badge/AppVersion-5.20.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/prowler-app)](https://artifacthub.io/packages/helm/prowler-app/prowler)
 

--- a/charts/prowler/Chart.yaml
+++ b/charts/prowler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prowler
 description: Prowler is an Open Cloud Security tool for AWS, Azure, GCP and Kubernetes. It helps for continuous monitoring, security assessments and audits, incident response, compliance, hardening and forensics readiness. 
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "5.20.0"
 home: https://prowler.com/
 icon: https://promptlylabs.github.io/prowler-helm-chart/docs/images/prowler-icon.jpeg

--- a/charts/prowler/templates/ui/configmap.yaml
+++ b/charts/prowler/templates/ui/configmap.yaml
@@ -8,6 +8,10 @@ data:
   {{- with (first .Values.ui.ingress.hosts) }}
   AUTH_URL: "https://{{ .host }}"
   {{- end }}
+  {{- else if .Values.ui.gatewayAPI.httpRoute.enabled }}
+  {{- with (first .Values.ui.gatewayAPI.httpRoute.hostnames) }}
+  AUTH_URL: "https://{{ . }}"
+  {{- end }}
   {{- else }}
   AUTH_URL: "http://localhost:{{ .Values.ui.service.port }}"
   {{- end }}

--- a/charts/prowler/templates/ui/httproute.yaml
+++ b/charts/prowler/templates/ui/httproute.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ui.gatewayAPI.httpRoute.enabled -}}
+{{- $fullName := printf "%s-ui" (include "prowler.fullname" .) -}}
+{{- $httpRoute := .Values.ui.gatewayAPI.httpRoute -}}
+{{- $svcPort := .Values.ui.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "prowler.labels" . | nindent 4 }}
+  {{- with $httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range $httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+  hostnames:
+    {{- range $httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  rules:
+    {{- range $httpRoute.rules }}
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+      matches:
+        {{- range .matches }}
+        - path:
+            type: {{ .path.type }}
+            value: {{ .path.value }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/prowler/values.schema.json
+++ b/charts/prowler/values.schema.json
@@ -407,6 +407,72 @@
                         }
                     }
                 },
+                "gatewayAPI": {
+                    "type": "object",
+                    "properties": {
+                        "httpRoute": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "hostnames": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "parentRefs": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "namespace": {
+                                                "type": "string"
+                                            },
+                                            "sectionName": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "rules": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "matches": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "path": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string"
+                                                                },
+                                                                "value": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/charts/prowler/values.yaml
+++ b/charts/prowler/values.yaml
@@ -146,6 +146,23 @@ ui:
     #    hosts:
     #      - chart-example.local
 
+  # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/gateway/
+  gatewayAPI:
+    httpRoute:
+      enabled: false
+      annotations: {}
+      parentRefs:
+        - name: gateway
+          namespace: ""
+          sectionName: ""
+      hostnames:
+        - prowler-ui.cluster.local
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Ingress is being slowly replaced with GatewayAPI and HTTPRoute ( https://kubernetes.io/blog/2026/01/29/ingress-nginx-statement/ ). This PR is enabling HTTPRoute support for UI by creating HTTPRoute resource and set up proper URL in UI config map.