### PR TITLE
feat: HTTPRoute AUTH_URL fix + bump Prowler to 5.31.1 (chart 0.0.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Images should use relative URLs.
 
 # Prowler Helm Chart
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square)
-![AppVersion: 5.20.0](https://img.shields.io/badge/AppVersion-5.20.0-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square)
+![AppVersion: 5.31.1](https://img.shields.io/badge/AppVersion-5.31.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/prowler-app)](https://artifacthub.io/packages/helm/prowler-app/prowler)
 
 Prowler is an Open Cloud Security tool for AWS, Azure, GCP and Kubernetes. It helps for continuos monitoring, security assessments and audits, incident response, compliance, hardening and forensics readiness. Includes CIS, NIST 800, NIST CSF, CISA, FedRAMP, PCI-DSS, GDPR, HIPAA, FFIEC, SOC2, GXP, Well-Architected Security, ENS and more.

--- a/charts/prowler/Chart.yaml
+++ b/charts/prowler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: prowler
 description: Prowler is an Open Cloud Security tool for AWS, Azure, GCP and Kubernetes. It helps for continuous monitoring, security assessments and audits, incident response, compliance, hardening and forensics readiness. 
 type: application
-version: 0.0.8
-appVersion: "5.20.0"
+version: 0.0.9
+appVersion: "5.31.1"
 home: https://prowler.com/
 icon: https://promptlylabs.github.io/prowler-helm-chart/docs/images/prowler-icon.jpeg
 keywords:
@@ -42,28 +42,17 @@ annotations:
     - name: support
       url: https://github.com/promptlylabs/prowler-helm-chart/issues
   artifacthub.io/changes: |
-    - kind: security
-      description: "Moved AUTH_SECRET from ConfigMap to a dedicated Secret resource with existingSecret support"
+    - kind: added
+      description: "Gateway API HTTPRoute support for the UI"
       links:
         - name: Github PR
-          url: https://github.com/promptlylabs/prowler-helm-chart/pull/8
-    - kind: added
-      description: "External secret support via existingSecret for PostgreSQL, Valkey, Neo4j, and UI auth"
-      links:
-        - name: Github PR
-          url: https://github.com/promptlylabs/prowler-helm-chart/pull/8
-    - kind: added
-      description: "Checksum annotations on all deployments for automatic pod restarts on config/secret changes"
-    - kind: added
-      description: "Security context defaults for all components (runAsNonRoot, drop ALL capabilities)"
-    - kind: fixed
-      description: "UI probes now target /sign-in instead of / which caused redirect failures"
+          url: https://github.com/promptlylabs/prowler-helm-chart/pull/9
     - kind: changed
-      description: "Worker-beat entrypoint changed to absolute path for consistency"
+      description: "Bump Prowler appVersion to 5.31.1"
     - kind: fixed
-      description: "Set fullnameOverride to 'prowler' so the API service matches the baked-in NEXT_PUBLIC_API_BASE_URL in the UI image"
+      description: "UI AUTH_URL now falls back to localhost when HTTPRoute is enabled without hostnames"
     - kind: added
-      description: "API startupProbe to allow time for DB migrations before liveness checks begin"
+      description: "Optional config docs: Celery worker concurrency, Attack Paths sink database, Valkey broker TLS/auth, CORS allowed origins"
 #   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/screenshots: |
     - title: Login

--- a/charts/prowler/README.md
+++ b/charts/prowler/README.md
@@ -5,8 +5,8 @@ Images should use absolute URLs.
 
 # Prowler Helm Chart
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square)
-![AppVersion: 5.20.0](https://img.shields.io/badge/AppVersion-5.20.0-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square)
+![AppVersion: 5.31.1](https://img.shields.io/badge/AppVersion-5.31.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/prowler-app)](https://artifacthub.io/packages/helm/prowler-app/prowler)
 
 Prowler is an Open Cloud Security tool for AWS, Azure, GCP and Kubernetes. It helps for continuos monitoring, security assessments and audits, incident response, compliance, hardening and forensics readiness. Includes CIS, NIST 800, NIST CSF, CISA, FedRAMP, PCI-DSS, GDPR, HIPAA, FFIEC, SOC2, GXP, Well-Architected Security, ENS and more.

--- a/charts/prowler/templates/api/secret-valkey.yaml
+++ b/charts/prowler/templates/api/secret-valkey.yaml
@@ -11,4 +11,7 @@ stringData:
   # VALKEY_PASSWORD: "valkey_password"
   VALKEY_PORT: "6379"
   VALKEY_DB: "0"
+  # Optional broker TLS/auth (added in 5.x); uncomment for managed Valkey/ElastiCache:
+  # VALKEY_SCHEME: "rediss"
+  # VALKEY_USERNAME: "default"
 {{- end -}}

--- a/charts/prowler/templates/ui/configmap.yaml
+++ b/charts/prowler/templates/ui/configmap.yaml
@@ -11,6 +11,8 @@ data:
   {{- else if .Values.ui.gatewayAPI.httpRoute.enabled }}
   {{- with (first .Values.ui.gatewayAPI.httpRoute.hostnames) }}
   AUTH_URL: "https://{{ . }}"
+  {{- else }}
+  AUTH_URL: "http://localhost:{{ $.Values.ui.service.port }}"
   {{- end }}
   {{- else }}
   AUTH_URL: "http://localhost:{{ .Values.ui.service.port }}"

--- a/charts/prowler/values.yaml
+++ b/charts/prowler/values.yaml
@@ -34,6 +34,9 @@ valkey:
   # - VALKEY_PORT
   # - VALKEY_PASSWORD
   # - VALKEY_DB
+  # Optional broker TLS/auth keys (added in 5.x), e.g. for ElastiCache/managed Valkey:
+  # - VALKEY_SCHEME    (e.g. "rediss" to enable TLS)
+  # - VALKEY_USERNAME
   enabled: true
   # If set, the chart will NOT auto-create the Valkey connection secret
   # and will reference this existing secret instead (e.g. from External Secrets Operator).
@@ -146,7 +149,7 @@ ui:
     #    hosts:
     #      - chart-example.local
 
-  # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/gateway/
+  # This block is for setting up the Gateway API HTTPRoute for the UI. More information can be found here: https://kubernetes.io/docs/concepts/services-networking/gateway/
   gatewayAPI:
     httpRoute:
       enabled: false
@@ -259,6 +262,10 @@ api:
     ATTACK_PATHS_SERVICE_UNAVAILABLE_MAX_RETRIES: "3"
     ATTACK_PATHS_READ_QUERY_TIMEOUT_SECONDS: "30"
     ATTACK_PATHS_MAX_CUSTOM_QUERY_NODES: "250"
+    # Persistent sink database for Attack Paths. One of [neo4j|neptune] (added in 5.x).
+    ATTACK_PATHS_SINK_DATABASE: "neo4j"
+    # Neo4j driver connection acquisition timeout in seconds (optional, added in 5.x)
+    # NEO4J_CONN_ACQUISITION_TIMEOUT: "15"
     # S3 Output settings (optional)
     # DJANGO_OUTPUT_S3_AWS_ACCESS_KEY_ID: ""
     # DJANGO_OUTPUT_S3_AWS_SECRET_ACCESS_KEY: ""
@@ -275,6 +282,15 @@ api:
     # Social login (optional) - add OAuth credentials via api.secrets
     # SOCIAL_GOOGLE_OAUTH_CLIENT_ID, SOCIAL_GOOGLE_OAUTH_CLIENT_SECRET
     # SOCIAL_GITHUB_OAUTH_CLIENT_ID, SOCIAL_GITHUB_OAUTH_CLIENT_SECRET
+    #
+    # Celery / task tuning (optional, added in 5.x)
+    # Celery worker concurrency. Leave unset for the upstream default.
+    # DJANGO_CELERY_WORKER_CONCURRENCY: "4"
+    # Automatic recovery of allowlisted idempotent background tasks (off by default).
+    # DJANGO_TASK_RECOVERY_ENABLED: "False"
+    #
+    # CORS (optional, added in 5.x) - comma-separated list of allowed origins
+    # CORS_ALLOWED_ORIGINS: "https://prowler.example.com"
   djangoConfigKeys:
     # Create secret with Django Keys
     # If false, a secret needs to be created with the following:


### PR DESCRIPTION
## Summary

Follow-up to #9 (Gateway API HTTPRoute for the UI) plus a bump of the Prowler App to the latest **5.31.1**. Ships as chart **0.0.9**.

### HTTPRoute (#9) review fixes
- **`ui/configmap.yaml`** — `AUTH_URL` now falls back to `http://localhost:<port>` when `httpRoute.enabled=true` but `hostnames` is empty. Gateway API permits hostname-less routes (they inherit the Gateway listener hostname); previously the ConfigMap emitted **no** `AUTH_URL` key at all, which breaks NextAuth.
- **`values.yaml`** — fix the copy-pasted "ingress" comment above the new `gatewayAPI` block.

### App version bump 5.20.0 → 5.31.1
- `Chart.yaml`: `appVersion` 5.20.0 → 5.31.1 (all four images — `api`, `ui`, `worker`, `worker_beat` — derive their tag from `.Chart.AppVersion`, so this cascades automatically), chart `version` 0.0.8 → 0.0.9.
- README badges (root + chart) and `artifacthub.io/changes` refreshed.
- **No new mandatory env vars or infra.** Verified against the latest `api/.env.example`, the API `CHANGELOG.md`, and upstream `docker-compose.yml`. New optional 5.x config is documented (values-only, no behavior change): `ATTACK_PATHS_SINK_DATABASE` (active default `neo4j`), `DJANGO_CELERY_WORKER_CONCURRENCY`, `DJANGO_TASK_RECOVERY_ENABLED`, `NEO4J_CONN_ACQUISITION_TIMEOUT`, `CORS_ALLOWED_ORIGINS`, and Valkey broker TLS/auth (`VALKEY_SCHEME`/`VALKEY_USERNAME`).

### Deliberately out of scope (flagged)
- Upstream's new optional `mcp-server` container — **not** added.
- Upstream `docker-compose` switched the graph DB image to DozerDB — **not** adopted; the chart keeps the official Neo4j subchart, which `ATTACK_PATHS_SINK_DATABASE=neo4j` still supports.
- The API now runs under Uvicorn/ASGI and uses Valkey Pub/Sub for SSE — image-internal; Valkey is already present, so no manifest change. Worth a smoke-test on first deploy given the 5.20 → 5.31.1 jump.

## Verification
- `helm lint` — 0 charts failed (with subchart deps vendored).
- `helm template` renders cleanly; all four images resolve to `:5.31.1`.
- AUTH_URL: enabled+hostname → `https://<host>`; enabled+empty hostnames → `http://localhost:3000` (the fix); disabled → `http://localhost:3000`.
- `values.schema.json` validation still passes (rejects bad types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)